### PR TITLE
Download all log data

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,7 @@
 {
   "presets": [
-    "es2015"
-  ]
+    "es2015",
+    "stage-3"
+  ],
+  "plugins": ["transform-runtime"]
 }

--- a/package.json
+++ b/package.json
@@ -14,11 +14,16 @@
   "license": "MIT",
   "devDependencies": {
     "babel-cli": "^6.24.1",
-    "babel-preset-es2015": "^6.24.1"
+    "babel-core": "^6.24.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-stage-3": "^6.24.1"
   },
   "dependencies": {
     "@google-cloud/bigquery": "^0.9.3",
     "aws-sdk": "^2.41.0",
+    "babel-polyfill": "^6.23.0",
+    "babel-runtime": "^6.23.0",
     "elasticsearch": "^13.0.0-rc2",
     "moment": "^2.18.1",
     "plpr": "^1.0.11"


### PR DESCRIPTION
## Background
RDS API "DownloadDBLogFilePortion" divide log files when that data size is over the 1MB.
ref. http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DownloadDBLogFilePortion.html

So, kuroneko can't insert All log data in data stores...

This PR change to download all log data using "Marker" and "AdditionalDataPending".
http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/RDS.html#downloadDBLogFilePortion-property