### PR TITLE
Fix duplicating logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   },
   "dependencies": {
     "@google-cloud/bigquery": "^0.9.3",
-    "aws-sdk": "^2.41.0",
+    "aws-sdk": "^2.42.0",
     "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.23.0",
     "elasticsearch": "^13.0.0-rc2",
     "moment": "^2.18.1",
-    "plpr": "^1.0.11"
+    "plpr": "^1.0.12"
   }
 }

--- a/src/bq.js
+++ b/src/bq.js
@@ -33,7 +33,9 @@ module.exports = (data, DBInstanceIdentifier) => {
   const path = '/tmp/' + config.table + '.json';
   fs.writeFileSync(path, json, 'utf-8');
 
-  return insert(client, config, schema, path).then().catch(error => {
+  return insert(client, config, schema, path).then(() => {
+    fs.unlinkSync(path);
+  }).catch(error => {
     throw error;
   });
 }

--- a/src/bq.js
+++ b/src/bq.js
@@ -2,52 +2,50 @@
 
 const moment = require('moment');
 const fs = require('fs');
-var config = null;
-var client = null;
-var schema = null;
 
 module.exports = (data, DBInstanceIdentifier) => {
+  let config = null;
   try {
-    init(DBInstanceIdentifier);
+    config = init(DBInstanceIdentifier);
   }
   catch(error) {
     return Promise.reject(error);
   };
 
   const type = require('./type')
-  var types = type(data[0]);
-  var contain = [];
+  let types = type(data[0]);
+  let contain = [];
   Object.keys(types).forEach((value, index, arr) => {
     contain.push(value+':'+types[value]);
   })
-  schema = contain.join(",");
+  let schema = contain.join(",");
 
   const bq = require('@google-cloud/bigquery');
-  client = bq({
+  let client = bq({
     projectId: config.projectId,
     keyFilename: config.keyFilename
   });
 
-  var json = '';
+  let json = '';
   data.forEach(obj => {
     json = json + JSON.stringify(obj) + '\n';
   });
   const path = '/tmp/' + config.table + '.json';
   fs.writeFileSync(path, json, 'utf-8');
 
-  return insert(path).then().catch(error => {
+  return insert(client, config, schema, path).then().catch(error => {
     throw error;
   });
 }
 
 function init(DBInstanceIdentifier) {
-  var tableBase = process.env.BQ_TABLE_BASE_NAME
+  let tableBase = process.env.BQ_TABLE_BASE_NAME
   if (typeof tableBase === 'undefined') {
     console.log('Not export table base name to "BQ_TABLE_BASE_NAME", use "AWS_DB_INSTANCE_IDENTIFIER": ' + DBInstanceIdentifier);
     tableBase = DBInstanceIdentifier;
   }
 
-  config = {
+  const config = {
     projectId: process.env.BQ_PROJECT_ID,
     dataset: process.env.BQ_DATASET_NAME,
     table: tableBase.replace(/-/g, "_")+ "_query_log" + moment().add(-1, 'h').format('YYYYMMDD'),
@@ -61,7 +59,7 @@ function init(DBInstanceIdentifier) {
   return config;
 }
 
-function dataset() {
+function dataset(client, config) {
   return client.dataset(config.dataset).exists().then(res => {
     if (!res[0]) {
       return client.createDataset(config.dataset).then(res => { return res[0] }).catch(error => {
@@ -74,8 +72,8 @@ function dataset() {
   });
 }
 
-function table() {
-  return dataset().then(dataset => {
+function table(client, config, schema) {
+  return dataset(client, config).then(dataset => {
     return dataset.table(config.table).exists().then(res => {
       if (!res[0]) {
         const options = {
@@ -93,8 +91,8 @@ function table() {
   });
 }
 
-function insert(path) {
-  return table().then(table => {
+function insert(client, config, schema, path) {
+  return table(client, config, schema).then(table => {
     table.import(path).then(() => {}).catch(error => {
       throw error;
     });

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,7 @@ async function downloadLogFile() {
     });
 
     params['LogFileName'] = files[files.length-2];
+    console.log('Downloading: ' + params['LogFileName'] + '...');
     let next = true;
     let marker = '0';
     let raw = '';


### PR DESCRIPTION
## Background
PostgreSQL log parser library of https://github.com/munisystem/plpr duplicated parsed data.
ref. https://github.com/munisystem/plpr/pull/4

AWS Lambda run process and call handler at that time.
And this process is terminated every six or seven hours.
So, call handler twice before terminated process, sending BigQuery data is duplicated and lose.

This PR update PostgreSQL log parser library and remove sending data file after creating BigQuery job.