### PR TITLE
Use DownloadCompleteDBLogFile API

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@google-cloud/bigquery": "^0.9.3",
     "aws-sdk": "^2.42.0",
+    "aws4": "^1.6.0",
     "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.23.0",
     "elasticsearch": "^13.0.0-rc2",


### PR DESCRIPTION
## Background
We usually use [DonwloadDBLogFilePortion API](http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DownloadDBLogFilePortion.html) when dowload RDS log files.

But sometimes failed to call this API.
Similar issues. https://forums.aws.amazon.com/thread.jspa?threadID=144248
> A client error (InvalidParameterValue) occurred when calling the DownloadDBLogFilePortion operation: This file contains binary data and should be downloaded instead of viewed.

It is happened in AWS Web Console...
 
This problem is avoided using [DownloadCompleteDBLogFile API](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/RESTReference.html) instead of DownloadDBLogFilePortion API.
However this is deprecated and don't support current aws-sdk versions.

Thun, we use [aws4](https://github.com/mhart/aws4).
